### PR TITLE
Fix drakes standing animations

### DIFF
--- a/units/drakes/Smasher.cfg
+++ b/units/drakes/Smasher.cfg
@@ -24,17 +24,7 @@
     [/resistance]
 
     [standing_anim]
-        start_time=0
-        [filter]
-            [filter_location]
-                terrain_type=!,W*,Qx*,Ql*
-                [or]
-                    terrain_type=Ww,Ww*,Wwr*,Ch*,Wsz,Wdz,*^V*
-                [/or]
-            [/filter_location]
-        [/filter]
         [frame]
-            duration=150
             image=units/drakes/sword.png
         [/frame]
     [/standing_anim]
@@ -42,14 +32,7 @@
         start_time=0
         layer=60
         submerge=0.01
-        [filter]
-            [filter_location]
-                terrain_type=W*,Qx*,Ql*
-                [not]
-                    terrain_type=Ww,Ww*,Wwr*,Ch*,Wsz,Wdz,*^V*
-                [/not]
-            [/filter_location]
-        [/filter]
+        terrain_type=!,Wwf*^*,Kme*^*,*^B*,!,W*^*,S*^*,Chs*^*,Chw*^*,Cm*^*,Km*^*,Q*^*,Mv*^*,*^Qov,*^Vm
         [frame]
             duration=100
             image=units/drakes/sword-fly-1.png

--- a/units/drakes/Subjugator.cfg
+++ b/units/drakes/Subjugator.cfg
@@ -23,17 +23,7 @@
     [/resistance]
 
     [standing_anim]
-        start_time=0
-        [filter]
-            [filter_location]
-                terrain_type=!,W*,Qx*,Ql*
-                [or]
-                    terrain_type=Ww,Ww*,Wwr*,Ch*,Wsz,Wdz,*^V*
-                [/or]
-            [/filter_location]
-        [/filter]
         [frame]
-            duration=150
             image=units/drakes/swordmaster.png
         [/frame]
     [/standing_anim]
@@ -41,14 +31,7 @@
         start_time=0
         layer=60
         submerge=0.01
-        [filter]
-            [filter_location]
-                terrain_type=W*,Qx*,Ql*
-                [not]
-                    terrain_type=Ww,Ww*,Wwr*,Ch*,Wsz,Wdz,*^V*
-                [/not]
-            [/filter_location]
-        [/filter]
+        terrain_type=!,Wwf*^*,Kme*^*,*^B*,!,W*^*,S*^*,Chs*^*,Chw*^*,Cm*^*,Km*^*,Q*^*,Mv*^*,*^Qov,*^Vm
         [frame]
             duration=100
             image=units/drakes/swordmaster-fly-1.png


### PR DESCRIPTION
Could use {DRAKE_UNWALKABLE_TERRAINS} macro instead.
We cannot use {DRAKE_STANDING_ANIM} tho, as smasher has no takeoff anim

closes #13 